### PR TITLE
Add OBJC to the list of languages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Acorn Archimedes Emulator
 
 cmake_minimum_required(VERSION 3.20)
-project(arculator VERSION 2.2 LANGUAGES C CXX)
+project(arculator VERSION 2.2 LANGUAGES C CXX OBJC)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Fix error about missing `CMAKE_OBJCXX_COMPILE_OBJECT` on macOS at the end of the configure step.

See, e.g., https://gitlab.kitware.com/cmake/cmake/-/issues/24104