### PR TITLE
Enable OBJC only when APPLE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@
 # Acorn Archimedes Emulator
 
 cmake_minimum_required(VERSION 3.20)
-project(arculator VERSION 2.2 LANGUAGES C CXX OBJC)
+project(arculator VERSION 2.2 LANGUAGES C CXX)
+if(APPLE)
+  enable_language(OBJC)
+endif()
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Fix issue noted with cmake 3.28.3 on Linux: configure step fails due to lack of Objective C++ compiler.