### PR TITLE
Implement menu as a pop-up like Linux

### DIFF
--- a/src/wx-win32.c
+++ b/src/wx-win32.c
@@ -181,6 +181,10 @@ void mainthread(LPVOID param)
 					updatemips = 1;
 					mouse_capture_enable();
 				}
+				else if (e.button.button == SDL_BUTTON_RIGHT && !mousecapture)
+				{
+					arc_popup_menu();
+				}
 			}
 			if (e.type == SDL_WINDOWEVENT)
 			{


### PR DESCRIPTION
Fixes #5 

Makes sense to just use the same right-click pop-up menu on Linux as we can't guarantee window size for top-level menu due to DPI, etc.